### PR TITLE
Initial commit for client-side filter

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -1,0 +1,69 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <groupId>com.wavefront</groupId>
+    <artifactId>wavefront-jaxrs-sdk-java</artifactId>
+    <version>0.9.0-SNAPSHOT</version>
+    <packaging>jar</packaging>
+
+    <name>Wavefront by VMware JAX-RS SDK for Java</name>
+    <description>Instruments JAX-RS-compliant APIs to send telemetry data to Wavefront from Java
+        applications.
+    </description>
+    <url>https://github.com/wavefrontHQ/wavefront-jaxrs-sdk-java</url>
+    <licenses>
+        <license>
+            <name>The Apache License, Version 2.0</name>
+            <url>http://www.apache.org/licenses/LICENSE-2.0.txt</url>
+        </license>
+    </licenses>
+
+    <scm>
+        <connection>scm:git:git@github.com:wavefrontHQ/wavefront-jaxrs-sdk-java.git</connection>
+        <developerConnection>scm:git:git@github.com:wavefrontHQ/wavefront-jaxrs-sdk-java.git
+        </developerConnection>
+        <url>git@github.com:wavefrontHQ/wavefront-jaxrs-sdk-java.git</url>
+    </scm>
+
+    <distributionManagement>
+        <snapshotRepository>
+            <id>ossrh</id>
+            <url>https://oss.sonatype.org/content/repositories/snapshots</url>
+        </snapshotRepository>
+    </distributionManagement>
+
+    <properties>
+        <java.version>1.8</java.version>
+    </properties>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-compiler-plugin</artifactId>
+                <version>3.1</version>
+                <configuration>
+                    <source>${java.version}</source>
+                    <target>${java.version}</target>
+                </configuration>
+            </plugin>
+        </plugins>
+    </build>
+
+    <dependencies>
+        <dependency>
+            <groupId>com.wavefront</groupId>
+            <artifactId>wavefront-opentracing-sdk-java</artifactId>
+            <version>0.9.2-SNAPSHOT</version>
+        </dependency>
+        <dependency>
+            <groupId>javax.ws.rs</groupId>
+            <artifactId>javax.ws.rs-api</artifactId>
+            <version>2.0.1</version>
+        </dependency>
+    </dependencies>
+
+</project>

--- a/pom.xml
+++ b/pom.xml
@@ -57,7 +57,7 @@
         <dependency>
             <groupId>com.wavefront</groupId>
             <artifactId>wavefront-opentracing-sdk-java</artifactId>
-            <version>0.9.2-SNAPSHOT</version>
+            <version>0.9.1</version>
         </dependency>
         <dependency>
             <groupId>javax.ws.rs</groupId>

--- a/src/main/java/com/wavefront/sdk/jaxrs/Constants.java
+++ b/src/main/java/com/wavefront/sdk/jaxrs/Constants.java
@@ -1,6 +1,6 @@
 package com.wavefront.sdk.jaxrs;
 
-import com.wavefront.sdk.jaxrs.client.ClientTracingFilter;
+import com.wavefront.sdk.jaxrs.client.WavefrontJaxrsClientFilter;
 
 import io.opentracing.References;
 
@@ -19,11 +19,16 @@ public class Constants {
   /**
    * Property name of the active span
    */
-  public static final String PROPERTY_NAME = ClientTracingFilter.class.getName() + ".activeSpan";
+  public static final String PROPERTY_NAME = WavefrontJaxrsClientFilter.class.getName() + ".activeSpan";
 
   /**
    * Property name of the child span
    */
-  public static final String CHILD_OF = ClientTracingFilter.class.getName() + "." +
+  public static final String CHILD_OF = WavefrontJaxrsClientFilter.class.getName() + "." +
       References.CHILD_OF;
+
+  /**
+   * Component name of the JAX-RS client
+   */
+  public static final String JAXRS_CLIENT_COMPONENT = "jaxrs-client";
 }

--- a/src/main/java/com/wavefront/sdk/jaxrs/Constants.java
+++ b/src/main/java/com/wavefront/sdk/jaxrs/Constants.java
@@ -1,0 +1,29 @@
+package com.wavefront.sdk.jaxrs;
+
+import com.wavefront.sdk.jaxrs.client.ClientTracingFilter;
+
+import io.opentracing.References;
+
+/**
+ * JAX-RS Client SDK constants.
+ *
+ * @author Hao Song (songhao@vmware.com).
+ */
+public class Constants {
+
+  /**
+   * Name of the header for span operation name from server side.
+   */
+  public static final String WF_SPAN_HEADER = "X-WF-SPAN-NAME";
+
+  /**
+   * Property name of the active span
+   */
+  public static final String PROPERTY_NAME = ClientTracingFilter.class.getName() + ".activeSpan";
+
+  /**
+   * Property name of the child span
+   */
+  public static final String CHILD_OF = ClientTracingFilter.class.getName() + "." +
+      References.CHILD_OF;
+}

--- a/src/main/java/com/wavefront/sdk/jaxrs/client/ClientHeadersInjectTextMap.java
+++ b/src/main/java/com/wavefront/sdk/jaxrs/client/ClientHeadersInjectTextMap.java
@@ -1,0 +1,32 @@
+package com.wavefront.sdk.jaxrs.client;
+
+import io.opentracing.propagation.TextMap;
+
+import java.util.Iterator;
+import java.util.Map;
+
+import javax.ws.rs.core.MultivaluedMap;
+
+/**
+ * Helper class used to add carrier data to HTTP headers.
+ */
+public class ClientHeadersInjectTextMap implements TextMap {
+
+  private final MultivaluedMap<String, Object> headers;
+
+  public ClientHeadersInjectTextMap(MultivaluedMap<String, Object> headers) {
+    this.headers = headers;
+  }
+
+  @Override
+  public Iterator<Map.Entry<String, String>> iterator() {
+    throw new UnsupportedOperationException(
+        ClientHeadersInjectTextMap.class.getName() + " should only be used with Tracer.inject()");
+  }
+
+  @Override
+  public void put(String key, String value) {
+    headers.add(key, value);
+  }
+
+}

--- a/src/main/java/com/wavefront/sdk/jaxrs/client/ClientHeadersInjectTextMap.java
+++ b/src/main/java/com/wavefront/sdk/jaxrs/client/ClientHeadersInjectTextMap.java
@@ -9,6 +9,8 @@ import javax.ws.rs.core.MultivaluedMap;
 
 /**
  * Helper class used to add carrier data to HTTP headers.
+ *
+ * @author Hao Song (songhao@vmware.com).
  */
 public class ClientHeadersInjectTextMap implements TextMap {
 
@@ -28,5 +30,4 @@ public class ClientHeadersInjectTextMap implements TextMap {
   public void put(String key, String value) {
     headers.add(key, value);
   }
-
 }

--- a/src/main/java/com/wavefront/sdk/jaxrs/client/ClientSpanDecorator.java
+++ b/src/main/java/com/wavefront/sdk/jaxrs/client/ClientSpanDecorator.java
@@ -61,16 +61,16 @@ public interface ClientSpanDecorator {
    * For non-instrumented server side, the operation name will be just HTTP method name.
    */
   ClientSpanDecorator WF_PATH_OPERATION_NAME = new ClientSpanDecorator() {
-    String methodName = "";
+    ThreadLocal<String> methodName = new ThreadLocal<>();
 
     @Override
     public void decorateRequest(ClientRequestContext clientRequestContext, Span span) {
-      this.methodName = clientRequestContext.getMethod();
+      this.methodName.set(clientRequestContext.getMethod());
     }
 
     @Override
     public void decorateResponse(ClientResponseContext response, Span span) {
-      String operationName = this.methodName;
+      String operationName = this.methodName.get();
       if (response.getHeaders().containsKey(WF_SPAN_HEADER)) {
         operationName += "-" + String.valueOf(response.getHeaders().getFirst(WF_SPAN_HEADER));
       }

--- a/src/main/java/com/wavefront/sdk/jaxrs/client/ClientSpanDecorator.java
+++ b/src/main/java/com/wavefront/sdk/jaxrs/client/ClientSpanDecorator.java
@@ -1,0 +1,81 @@
+package com.wavefront.sdk.jaxrs.client;
+
+import io.opentracing.Span;
+
+import java.net.MalformedURLException;
+
+import io.opentracing.tag.Tags;
+
+import javax.ws.rs.client.ClientRequestContext;
+import javax.ws.rs.client.ClientResponseContext;
+
+import static com.wavefront.sdk.jaxrs.Constants.WF_SPAN_HEADER;
+
+/**
+ * Decorators for span tags and operation name.
+ *
+ * @author Hao Song (songhao@vmware.com).
+ */
+public interface ClientSpanDecorator {
+
+  /**
+   * Decorate get by incoming object.
+   */
+  void decorateRequest(ClientRequestContext requestContext, Span span);
+
+  /**
+   * Decorate spans by outgoing object.
+   */
+  void decorateResponse(ClientResponseContext responseContext, Span span);
+
+  /**
+   * Adds standard tags:
+   * {@link io.opentracing.tag.Tags#SPAN_KIND}, {@link io.opentracing.tag.Tags#COMPONENT},
+   * {@link io.opentracing.tag.Tags#HTTP_METHOD}, {@link io.opentracing.tag.Tags#HTTP_URL},
+   * {@link io.opentracing.tag.Tags#HTTP_STATUS}, {@link io.opentracing.tag.Tags#ERROR}
+   */
+  ClientSpanDecorator STANDARD_TAGS = new ClientSpanDecorator() {
+    @Override
+    public void decorateRequest(ClientRequestContext requestContext, Span span) {
+      Tags.COMPONENT.set(span, "jaxrs-client");
+      Tags.HTTP_METHOD.set(span, requestContext.getMethod());
+      try {
+        Tags.HTTP_URL.set(span, requestContext.getUri().toURL().toString());
+      } catch (MalformedURLException e) {
+        // ignoring returning null
+      }
+    }
+
+    @Override
+    public void decorateResponse(ClientResponseContext responseContext, Span span) {
+      Tags.HTTP_STATUS.set(span, responseContext.getStatus());
+      int statusCode = responseContext.getStatus();
+      if (statusCode >= 400 && statusCode <= 599) {
+        Tags.ERROR.set(span, true);
+      }
+    }
+  };
+
+  /**
+   * Set operation of the span using the server-side path injected by Wavefront Filter.
+   * For non-instrumented server side, the operation name will be just HTTP method name.
+   */
+  ClientSpanDecorator WF_PATH_OPERATION_NAME = new ClientSpanDecorator() {
+    String methodName = "";
+
+    @Override
+    public void decorateRequest(ClientRequestContext clientRequestContext, Span span) {
+      this.methodName = clientRequestContext.getMethod();
+    }
+
+    @Override
+    public void decorateResponse(ClientResponseContext response, Span span) {
+      String operationName = this.methodName;
+      if (response.getHeaders().containsKey(WF_SPAN_HEADER)) {
+        operationName += "-" + String.valueOf(response.getHeaders().getFirst(WF_SPAN_HEADER));
+      }
+      span.setOperationName(operationName);
+    }
+  };
+
+}

--- a/src/main/java/com/wavefront/sdk/jaxrs/client/ClientSpanDecorator.java
+++ b/src/main/java/com/wavefront/sdk/jaxrs/client/ClientSpanDecorator.java
@@ -9,6 +9,7 @@ import io.opentracing.tag.Tags;
 import javax.ws.rs.client.ClientRequestContext;
 import javax.ws.rs.client.ClientResponseContext;
 
+import static com.wavefront.sdk.jaxrs.Constants.JAXRS_CLIENT_COMPONENT;
 import static com.wavefront.sdk.jaxrs.Constants.WF_SPAN_HEADER;
 
 /**
@@ -37,7 +38,7 @@ public interface ClientSpanDecorator {
   ClientSpanDecorator STANDARD_TAGS = new ClientSpanDecorator() {
     @Override
     public void decorateRequest(ClientRequestContext requestContext, Span span) {
-      Tags.COMPONENT.set(span, "jaxrs-client");
+      Tags.COMPONENT.set(span, JAXRS_CLIENT_COMPONENT);
       Tags.HTTP_METHOD.set(span, requestContext.getMethod());
       try {
         Tags.HTTP_URL.set(span, requestContext.getUri().toURL().toString());

--- a/src/main/java/com/wavefront/sdk/jaxrs/client/ClientTracingFilter.java
+++ b/src/main/java/com/wavefront/sdk/jaxrs/client/ClientTracingFilter.java
@@ -1,0 +1,76 @@
+package com.wavefront.sdk.jaxrs.client;
+
+import io.opentracing.Span;
+import io.opentracing.SpanContext;
+import io.opentracing.Tracer;
+
+import io.opentracing.propagation.Format;
+import io.opentracing.tag.Tags;
+
+import java.io.IOException;
+import java.util.Arrays;
+import java.util.List;
+
+import javax.annotation.Nullable;
+import javax.ws.rs.client.ClientRequestContext;
+import javax.ws.rs.client.ClientRequestFilter;
+import javax.ws.rs.client.ClientResponseContext;
+import javax.ws.rs.client.ClientResponseFilter;
+
+import static com.wavefront.sdk.jaxrs.Constants.PROPERTY_NAME;
+import static com.wavefront.sdk.jaxrs.Constants.CHILD_OF;
+
+/**
+ * A filter to generate Wavefront client side span for JAX-RS based API requests/responses.
+ *
+ * @author Hao Song (songhao@vmware.com).
+ */
+public class ClientTracingFilter implements ClientRequestFilter, ClientResponseFilter {
+
+  @Nullable
+  private Tracer tracer;
+  private List<ClientSpanDecorator> spanDecorators;
+
+  public ClientTracingFilter(@Nullable Tracer tracer) {
+    this.tracer = tracer;
+    this.spanDecorators = Arrays.asList(ClientSpanDecorator.STANDARD_TAGS,
+        ClientSpanDecorator.WF_PATH_OPERATION_NAME);
+  }
+
+  @Override
+  public void filter(ClientRequestContext requestContext) throws IOException {
+    if (requestContext.getProperty(PROPERTY_NAME) != null) {
+      return;
+    }
+    if (tracer != null) {
+      Tracer.SpanBuilder spanBuilder = tracer.buildSpan(requestContext.getMethod())
+          .withTag(Tags.SPAN_KIND.getKey(), Tags.SPAN_KIND_CLIENT);
+      SpanContext parentSpanContext = (SpanContext) requestContext.getProperty(CHILD_OF);
+      if (parentSpanContext != null) {
+        spanBuilder.ignoreActiveSpan().asChildOf(parentSpanContext);
+      }
+      final Span span = spanBuilder.start();
+      for (ClientSpanDecorator decorator : spanDecorators) {
+        decorator.decorateRequest(requestContext, span);
+      }
+      tracer.inject(span.context(), Format.Builtin.HTTP_HEADERS, new ClientHeadersInjectTextMap(
+          requestContext.getHeaders()));
+      requestContext.setProperty(PROPERTY_NAME, span);
+    }
+  }
+
+  @Override
+  public void filter(ClientRequestContext requestContext, ClientResponseContext responseContext)
+      throws IOException {
+    if (tracer != null) {
+      Span span = (Span) requestContext.getProperty(PROPERTY_NAME);
+      if (span != null) {
+        for (ClientSpanDecorator decorator : spanDecorators) {
+          decorator.decorateResponse(responseContext, span);
+        }
+        span.finish();
+      }
+    }
+  }
+
+}

--- a/src/main/java/com/wavefront/sdk/jaxrs/client/ClientTracingFilter.java
+++ b/src/main/java/com/wavefront/sdk/jaxrs/client/ClientTracingFilter.java
@@ -28,8 +28,8 @@ import static com.wavefront.sdk.jaxrs.Constants.CHILD_OF;
 public class ClientTracingFilter implements ClientRequestFilter, ClientResponseFilter {
 
   @Nullable
-  private Tracer tracer;
-  private List<ClientSpanDecorator> spanDecorators;
+  private final Tracer tracer;
+  private final List<ClientSpanDecorator> spanDecorators;
 
   public ClientTracingFilter(@Nullable Tracer tracer) {
     this.tracer = tracer;
@@ -72,5 +72,4 @@ public class ClientTracingFilter implements ClientRequestFilter, ClientResponseF
       }
     }
   }
-
 }

--- a/src/main/java/com/wavefront/sdk/jaxrs/client/WavefrontJaxrsClientFilter.java
+++ b/src/main/java/com/wavefront/sdk/jaxrs/client/WavefrontJaxrsClientFilter.java
@@ -1,5 +1,9 @@
 package com.wavefront.sdk.jaxrs.client;
 
+import com.wavefront.sdk.common.WavefrontSender;
+import com.wavefront.sdk.common.application.ApplicationTags;
+import com.wavefront.sdk.common.application.HeartbeaterService;
+
 import io.opentracing.Span;
 import io.opentracing.SpanContext;
 import io.opentracing.Tracer;
@@ -17,6 +21,7 @@ import javax.ws.rs.client.ClientRequestFilter;
 import javax.ws.rs.client.ClientResponseContext;
 import javax.ws.rs.client.ClientResponseFilter;
 
+import static com.wavefront.sdk.jaxrs.Constants.JAXRS_CLIENT_COMPONENT;
 import static com.wavefront.sdk.jaxrs.Constants.PROPERTY_NAME;
 import static com.wavefront.sdk.jaxrs.Constants.CHILD_OF;
 
@@ -25,16 +30,20 @@ import static com.wavefront.sdk.jaxrs.Constants.CHILD_OF;
  *
  * @author Hao Song (songhao@vmware.com).
  */
-public class ClientTracingFilter implements ClientRequestFilter, ClientResponseFilter {
+public class WavefrontJaxrsClientFilter implements ClientRequestFilter, ClientResponseFilter {
 
   @Nullable
   private final Tracer tracer;
   private final List<ClientSpanDecorator> spanDecorators;
 
-  public ClientTracingFilter(@Nullable Tracer tracer) {
+  public WavefrontJaxrsClientFilter(WavefrontSender sender, ApplicationTags applicationTags,
+                                    String source, @Nullable Tracer tracer) {
     this.tracer = tracer;
     this.spanDecorators = Arrays.asList(ClientSpanDecorator.STANDARD_TAGS,
         ClientSpanDecorator.WF_PATH_OPERATION_NAME);
+    HeartbeaterService heartbeaterService = new HeartbeaterService(sender, applicationTags,
+        JAXRS_CLIENT_COMPONENT, source);
+    heartbeaterService.run();
   }
 
   @Override

--- a/src/main/java/com/wavefront/sdk/jaxrs/client/WavefrontJaxrsClientFilter.java
+++ b/src/main/java/com/wavefront/sdk/jaxrs/client/WavefrontJaxrsClientFilter.java
@@ -15,6 +15,7 @@ import java.io.IOException;
 import java.util.Arrays;
 import java.util.List;
 
+import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
 import javax.ws.rs.client.ClientRequestContext;
 import javax.ws.rs.client.ClientRequestFilter;
@@ -36,14 +37,13 @@ public class WavefrontJaxrsClientFilter implements ClientRequestFilter, ClientRe
   private final Tracer tracer;
   private final List<ClientSpanDecorator> spanDecorators;
 
-  public WavefrontJaxrsClientFilter(WavefrontSender sender, ApplicationTags applicationTags,
-                                    String source, @Nullable Tracer tracer) {
+  public WavefrontJaxrsClientFilter(WavefrontSender wfSender, ApplicationTags applicationTags,
+                                    @Nonnull String source, @Nullable Tracer tracer) {
     this.tracer = tracer;
     this.spanDecorators = Arrays.asList(ClientSpanDecorator.STANDARD_TAGS,
         ClientSpanDecorator.WF_PATH_OPERATION_NAME);
-    HeartbeaterService heartbeaterService = new HeartbeaterService(sender, applicationTags,
+    HeartbeaterService heartbeaterService = new HeartbeaterService(wfSender, applicationTags,
         JAXRS_CLIENT_COMPONENT, source);
-    heartbeaterService.run();
   }
 
   @Override


### PR DESCRIPTION
- Since we did not find a way to get class/method name from the client side, the current implementation remains using headers for span operation name. For server-side instrumented with Wavefront Jersey Filter (PR for Jersey SDK changes: https://github.com/wavefrontHQ/wavefront-jersey-sdk-java/pull/29), the span will look like `GET-style/{id}/make`, otherwise, it will just be `GET`.
- Also, fix the error tag for client side, will set `error: "true"` if server-side response with error status code.