### PR TITLE
Making WavefrontJaxrsServerFilter class extendable.

### DIFF
--- a/src/main/java/com/wavefront/sdk/jaxrs/server/WavefrontJaxrsServerFilter.java
+++ b/src/main/java/com/wavefront/sdk/jaxrs/server/WavefrontJaxrsServerFilter.java
@@ -69,7 +69,7 @@ public class WavefrontJaxrsServerFilter implements ContainerRequestFilter, Conta
   @Context
   private ResourceInfo resourceInfo;
 
-  private WavefrontJaxrsServerFilter(SdkReporter wfJaxrsReporter, ApplicationTags applicationTags,
+  public WavefrontJaxrsServerFilter(SdkReporter wfJaxrsReporter, ApplicationTags applicationTags,
                                      @Nullable Tracer tracer, Set<String> headerTags) {
     if (wfJaxrsReporter == null)
       throw new NullPointerException("Invalid JAX-RS Reporter");


### PR DESCRIPTION
Making this constructor public would make this class extendable. This would help the adopters of the library populate custom span contexts/tags  based on the in-flight RPC request/response.
